### PR TITLE
Replace / in branch names with - when creating the version string

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -49,7 +49,7 @@ env:
             worktree-clean? (not (or untracked-files? changed-files? staged-files?))
             version-str (format "%s-%s-%s%s"
                                 date-str
-                                branch-name
+                                (str/replace branch-name "/" "-")
                                 short-hash
                                 (if worktree-clean? "" "-UNCLEAN"))]
         (when-not worktree-clean?


### PR DESCRIPTION
`/` are supported by git but not by image repositories, resulting in failed pushes. I don't have much of an opinion wrt the use of it in branch names, but I don't think their use should break the action's functionality. 