### PR TITLE
Use new output environment files

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -92,4 +92,4 @@ jobs:
           tmpdir="${{ runner.temp }}"
           version_id=$($tmpdir/version.bb)
           echo "Computed version identifier: ${version_id}"
-          echo "::set-output name=version_id::${version_id}"
+          echo "version_id=${version_id}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub have deprecated the old `set-output` method in favour of environment files, so this change should remove the deprecation warning when using this reusable action. More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/